### PR TITLE
Two small bugs fixed

### DIFF
--- a/src/Authorizer.php
+++ b/src/Authorizer.php
@@ -65,10 +65,10 @@ class Authorizer
     public function scope($user, $scope, callable $lookup = null)
     {
         $record = is_null($lookup) ? $scope : call_user_func($lookup, $scope);
-        $scope  = (new Resolver($record))->scope();
+        $scopeClass  = (new Resolver($record))->scope();
 
         if ( ! is_null($scope)) {
-            return (new $scope($user, $scope))->resolve();
+            return (new $scopeClass($user, $scope))->resolve();
         }
     }
 

--- a/src/Authorizer.php
+++ b/src/Authorizer.php
@@ -25,7 +25,7 @@ class Authorizer
     {
         $policy = $this->policyOrFail($user, $record);
         $result = $policy->$action();
-        $options = array_merge(compact('query', 'record', 'policy'), [ 'message' => $result ]);
+        $options = array_merge(compact('query', 'record', 'policy', 'action'), [ 'message' => $result ]);
 
         if ($result !== true) {
             throw new NotAuthorizedException($options);

--- a/src/ProvidesAuthorization.php
+++ b/src/ProvidesAuthorization.php
@@ -66,7 +66,7 @@ trait ProvidesAuthorization
 
         $policy  = $this->policy($record);
         $result  = $policy->$action();
-        $options = array_merge(compact('query', 'record', 'policy'), [ 'message' => $result ]);
+        $options = array_merge(compact('query', 'record', 'policy', 'action'), [ 'message' => $result ]);
 
         if ($result !== true) {
             throw new NotAuthorizedException($options);


### PR DESCRIPTION
Added the "action" variable to the options sent to the exceptions, so the message is well formed. As you can see, an "action" is expected to show the message:
`sprintf('Not allowed to %s this %s', $this->action, $recordName)`

Also, a bug was fixed on the scope function of the authorizer class. The variable "scope" received as a parameter was being overwritten. Renamed that variable and used the new name to create the new object :
`return (new $scopeClass($user, $scope))->resolve();`

used to be:
`return (new $scope($user, $scope))->resolve();`
